### PR TITLE
Fixed updateToken function to load the right value

### DIFF
--- a/src/components/Context/AuthProvider.js
+++ b/src/components/Context/AuthProvider.js
@@ -7,7 +7,7 @@ class AuthProvider extends Component {
 
     this.updateToken = () =>
       this.setState({
-        token: localStorage.getItem('mcart'),
+        token: localStorage.getItem('customerToken'),
       })
 
     this.state = {


### PR DESCRIPTION
updateToken was updating the token state with mcart value instead of customerToken
from from the localStorage. The mcart value is the cartId. New tokens are stored in
customerToken key in the localStorage