### PR TITLE
Update broken tests and outdated dependencies

### DIFF
--- a/cypress/e2e/product-page.js
+++ b/cypress/e2e/product-page.js
@@ -1,12 +1,11 @@
 describe('add to cart', () => {
   it('should allow me to add a product to the cart', () => {
     cy.visit('/')
-      .waitForRouteChange()
-      .getByText(/multi-vibe/i)
+      .contains('Multi-Vibe')
       .click({force: true})
-      .waitForRouteChange()
-      .getByText(/add to cart/i)
+      .wait(500)
+      .findByText(/add to cart/i)
       .click({force: true})
-      .getByText(/added to cart/i)
+      .findByText(/added to cart/i)
   })
 })

--- a/cypress/e2e/smoke.js
+++ b/cypress/e2e/smoke.js
@@ -1,8 +1,8 @@
 describe('app', () => {
   it('works', () => {
     cy.visit('/')
-      .getByText(/terms/i)
+      .findByText(/terms/i)
       .click()
-      .getByText(/lorem ipsizzle/i)
+      .findByText(/lorem ipsizzle/i)
   })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,4 +1,4 @@
-import 'cypress-testing-library/add-commands'
+import '@testing-library/cypress/add-commands'
 
 Cypress.Commands.add('assertRoute', route => {
   cy.url().should('equal', `${window.location.origin}${route}`)

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import 'cypress-testing-library/add-commands'
+import '@testing-library/cypress/add-commands'
 import 'gatsby-cypress/commands'
 import './commands'
 

--- a/package.json
+++ b/package.json
@@ -36,12 +36,13 @@
     "styled-components": "^4.3.2"
   },
   "devDependencies": {
+    "@testing-library/cypress": "^5.0.1",
+    "@testing-library/react": "^9.3.0",
     "babel-eslint": "^10.0.3",
     "babel-plugin-remove-graphql-queries": "^2.7.5",
     "babel-plugin-styled-components": "^1.10.6",
     "cross-env": "^5.2.0",
     "cypress": "^3.4.1",
-    "cypress-testing-library": "^4.0.0",
     "dotenv": "^8.1.0",
     "eslint": "^6.3.0",
     "eslint-config-airbnb": "^18.0.1",
@@ -59,7 +60,6 @@
     "jest": "^24.9.0",
     "lint-staged": "^9.2.5",
     "prettier": "^1.18.2",
-    "react-testing-library": "^8.0.1",
     "regenerator-runtime": "^0.13.3",
     "rimraf": "^3.0.0",
     "start-server-and-test": "^1.10.0"

--- a/src/pages/__tests__/login.js
+++ b/src/pages/__tests__/login.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {render, fireEvent, cleanup} from 'react-testing-library'
+import {render, fireEvent, cleanup} from '@testing-library/react'
 import Login from '../login'
 
 afterEach(cleanup)

--- a/src/pages/__tests__/register.js
+++ b/src/pages/__tests__/register.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {render} from 'react-testing-library'
+import {render} from '@testing-library/react'
 import Register from '../register'
 
 const props = {location: {pathname: ''}}


### PR DESCRIPTION
- Dependencies `cypress-testing-library` and `react-testing-library` which were
deprecated and replaced by `@testing-library/cypress` and
`@testing-library/react` respectively were the reason the
tests were failing. To fix the tests these libraries were updated.

- e2e tests which were using `waitForRouteChange` method were failing,
for some reason they were reaching a timeout error. That method was
replaced by the original wait on Cypress to avoid the timeout error; it
might better to try to find the issue on `waitForRouteChange`, but that
could take more time, maybe an issue should be open on gatsby.